### PR TITLE
abort script execution on errors

### DIFF
--- a/Framework_Laptop_11th_Gen_Intel_Core_BIOS_3.19_EFI.sh
+++ b/Framework_Laptop_11th_Gen_Intel_Core_BIOS_3.19_EFI.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 dlurl='https://downloads.frame.work/bios'
 # This is the 3.17 EFI update containing:
 #  * H2OFFT-Sx64.efi: The H2O Firmware Flash Tool for the UEFI Shell x64


### PR DESCRIPTION
To make debugging easier, abort the script when there are errors. Examples of errors can be that `unrar` or `7za` are not installed yet.